### PR TITLE
fix/race-condition

### DIFF
--- a/src/PeakWatch/ViewModel/ExportViewModel.swift
+++ b/src/PeakWatch/ViewModel/ExportViewModel.swift
@@ -58,15 +58,14 @@ class ExportViewModel: ObservableObject {
         }
         
         self.algorithmViewModels.forEach { algorithmViewModel in
-            registerObserver(observable: algorithmViewModel, observer: algorithmViewModel.$qrsResultsByAlgorithm)
-            registerObserver(observable: algorithmViewModel, observer: algorithmViewModel.$ecgQualityByAlgortihm)
+            registerObserver(observable: algorithmViewModel, observer: algorithmViewModel.$canExport)
         }
     }
     
     func registerObserver<T>(observable: AlgorithmViewModel, observer: Published<T>.Publisher) {
         observer
             .dropFirst()
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main) 
             .sink(receiveValue: { [weak self] _ in
                 self?.appendExportedECG(from: observable)
             }


### PR DESCRIPTION
I think I found the bug causing the race condition. 

The problem was that we had registered two listeners for the update event of (1) ecg quality and (2) peak detectors.
Because of two listeners, it can happen that two result duplicates are added. 

The previous flow was expected like this:

(a1) calculate detectors -> (l1) listeners verifies if detectors and ecg quality is done ->  typically false as ECG quality not calculated -> (a2) calculate ecg quality -> (l2) listener verifies if detectors and ecg quality is done -> true

However, keep in mind that everything is asynchronous. Therefore, it can happen that (a2) happens before (l1). If that happens (l1) is true and it creates an export entity. (l2) is also true and creates the duplicated second export entity.
Before, that issue was not present because the runtimes of (a2) was long enough that (l1) was false every time. With the runtime optimization, this guarantee dropped. 


I solved the problem by simplifying everything. I created only one listener and ensured that all state updates happen at the DispatchQueue.main. I think that is a good design and should not create performance bottlenecks. 